### PR TITLE
Fix update brand and category endpoints

### DIFF
--- a/src/brand/brand.controller.ts
+++ b/src/brand/brand.controller.ts
@@ -73,6 +73,7 @@ export class BrandController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: BrandUpdateResponse })
   @ApiNotFoundResponse({ type: BrandNotFoundResponse })
+  @ApiConflictResponse({ type: BrandConflictResponse })
   public async update(@Param('id') id: string, @Body() dto: UpdateBrandDto) {
     const category = await this._brandService.update(id, dto);
 

--- a/src/brand/brand.service.ts
+++ b/src/brand/brand.service.ts
@@ -21,6 +21,12 @@ export class BrandService {
     return brand;
   }
 
+  public async getByTitle(title: string): Promise<Brand> {
+    const brand = await this._client.brand.findFirst({ where: { title } });
+
+    return brand;
+  }
+
   public async getAll(): Promise<Brand[]> {
     const brands = await this._client.brand.findMany();
 
@@ -30,9 +36,7 @@ export class BrandService {
   public async create(
     dto: CreateBrandDto,
   ): Promise<{ brand: Brand; message: string }> {
-    const existedBrand = await this._client.brand.findFirst({
-      where: { title: dto.title },
-    });
+    const existedBrand = await this.getByTitle(dto.title);
 
     if (existedBrand)
       throw new ConflictException(BrandErrors.BRAND_ALREADY_EXIST);
@@ -49,6 +53,11 @@ export class BrandService {
     const existedBrand = await this.getById(id);
 
     if (!existedBrand) throw new NotFoundException(BrandErrors.BRAND_NOT_FOUND);
+
+    const isTitleAlreadyUse = await this.getByTitle(dto.title);
+
+    if (isTitleAlreadyUse)
+      throw new ConflictException(BrandErrors.BRAND_ALREADY_EXIST);
 
     const updatedBrand = await this._client.brand.update({
       where: { id },

--- a/src/brand/types/brand.responses.ts
+++ b/src/brand/types/brand.responses.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { Brand } from '@prisma/client';
 
-import { BrandErrors, ValidationErrors } from '@/constants';
+import { BrandErrors, BrandMessages, ValidationErrors } from '@/constants';
 
 export class BrandResponse {
   @ApiProperty({ example: '51846bf6-1f2a-4d65-85b2-c3e187c4d9ee' })
@@ -13,7 +13,7 @@ export class BrandResponse {
 }
 
 export class BrandMessageResponse {
-  @ApiProperty({ example: 'Категория успешно удалена!' })
+  @ApiProperty({ example: BrandMessages.BRAND_DELETE_SUCCESS })
   message: string;
 }
 

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -35,12 +35,14 @@ import {
   CategoryMessageResponse,
   CategoryOkResponse,
   CategoryUpdateResponse,
-} from './types';
+} from './types/category.responses';
 
 @Controller('category')
 @ApiTags('category')
 export class CategoryController {
   constructor(private readonly _categoryService: CategoryService) {}
+
+  // TODO: Add success message at create endpoint to response
 
   @Post()
   @HttpCode(201)
@@ -72,6 +74,7 @@ export class CategoryController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: CategoryUpdateResponse })
   @ApiBadRequestResponse({ type: CategoryBadRequestResponse })
+  @ApiConflictResponse({ type: CategoryConflictResponse })
   public async update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
     const category = await this._categoryService.update(id, dto);
 

--- a/src/category/types/category.responses.ts
+++ b/src/category/types/category.responses.ts
@@ -2,6 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { Category } from '@prisma/client';
 
+import { CategoryErrors, ValidationErrors } from '@/constants';
+
 export class CategoryOkResponse {
   @ApiProperty({ example: '51846bf6-1f2a-4d65-85b2-c3e187c4d9ee' })
   id: string;
@@ -21,7 +23,7 @@ export class CategoryUpdateResponse extends CategoryMessageResponse {
 }
 
 export class CategoryBadRequestResponse {
-  @ApiProperty({ example: 'Категория не найдена!' })
+  @ApiProperty({ example: CategoryErrors.CATEGORY_NOT_FOUND })
   message: string;
 
   @ApiProperty({ example: 'Bad Request' })
@@ -32,7 +34,10 @@ export class CategoryBadRequestResponse {
 }
 
 export class CategoryCreateBadRequestResponse {
-  @ApiProperty({ example: 'Укажите название категории!', isArray: true })
+  @ApiProperty({
+    example: ValidationErrors.CATEGORY_EMPTY_TITLE,
+    isArray: true,
+  })
   message: string;
 
   @ApiProperty({ example: 'Bad Request' })
@@ -43,7 +48,7 @@ export class CategoryCreateBadRequestResponse {
 }
 
 export class CategoryConflictResponse {
-  @ApiProperty({ example: 'Такая категория уже есть в системе!' })
+  @ApiProperty({ example: CategoryErrors.CATEGORY_ALREADY_EXIST })
   message: string;
 
   @ApiProperty({ example: 'Conflict' })

--- a/src/category/types/index.ts
+++ b/src/category/types/index.ts
@@ -1,1 +1,0 @@
-export * from './category.responses';

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
 
   const config = new DocumentBuilder()
     .setTitle('Cartzilla API')
-    .setVersion('0.0.2')
+    .setVersion('0.0.3')
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
*What's new*:

- Update swagger documentation
- Now when the admin updates the brand or category to an existing one, an error is displayed